### PR TITLE
Update URL for plugins.jenkins.io

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
 
     <name>Hashicorp Vault Pipeline Plugin</name>
     <description>Enables pulling of vault values as a pipeline step</description>
+    <url>https://github.com/jenkinsci/hashicorp-vault-pipeline-plugin/</url>
     <licenses>
         <license>
             <name>MIT License</name>


### PR DESCRIPTION
Update for pom.xml that enables docs on https://plugins.jenkins.io/hashicorp-vault-pipeline

#hacktoberfest