### PR TITLE
Added support for reading vault engine version from global config

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Enables the use of vault from within a pipeline.
 pipeline {
     agent any
     environment {
-        SECRET = vault path: 'secrets', key: 'username', engineVersion: "2"
+        SECRET = vault path: 'secrets', key: 'username'
     }
     stages {
         stage("read vault key") {

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>com.datapipe.jenkins.plugins</groupId>
             <artifactId>hashicorp-vault-plugin</artifactId>
-            <version>3.0.0</version>
+            <version>2.4.0</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>com.datapipe.jenkins.plugins</groupId>
             <artifactId>hashicorp-vault-plugin</artifactId>
-            <version>2.3.0</version>
+            <version>3.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/io/jenkins/plugins/vault/VaultReadStep.java
+++ b/src/main/java/io/jenkins/plugins/vault/VaultReadStep.java
@@ -96,14 +96,12 @@ public class VaultReadStep extends Step {
         }
 
         private int getEngineVersion(EnvVars environment) {
-            String versionString = Util.replaceMacro(step.engineVersion, environment);
-
-            if (versionString == null || versionString.isEmpty()) {
+            if (step.engineVersion == null || step.engineVersion.isEmpty()) {
                 GlobalVaultConfiguration vaultConfig = GlobalConfiguration.all().get(GlobalVaultConfiguration.class);
                 return vaultConfig.getConfiguration().getEngineVersion();
             }
 
-            return Integer.parseInt(versionString);
+            return Integer.parseInt(Util.replaceMacro(step.engineVersion, environment));
         }
 
         @Override

--- a/src/main/java/io/jenkins/plugins/vault/VaultReadStep.java
+++ b/src/main/java/io/jenkins/plugins/vault/VaultReadStep.java
@@ -95,12 +95,23 @@ public class VaultReadStep extends Step {
             return vaultAccessor;
         }
 
+        private int getEngineVersion(EnvVars environment) {
+            String versionString = Util.replaceMacro(step.engineVersion, environment);
+
+            if (versionString == null || versionString.isEmpty()) {
+                GlobalVaultConfiguration vaultConfig = GlobalConfiguration.all().get(GlobalVaultConfiguration.class);
+                return vaultConfig.getConfiguration().getEngineVersion();
+            }
+
+            return Integer.parseInt(versionString);
+        }
+
         @Override
         public boolean start() throws Exception {
             try {
                 EnvVars environment = getEnvironment();
                 String path = Util.replaceMacro(step.path, environment);
-                Integer engineVersion = Integer.parseInt(Util.replaceMacro(step.engineVersion, environment));
+                Integer engineVersion = getEngineVersion(environment);
                 String key = Util.replaceMacro(step.key, environment);
                 String value = getAccessor(getContext().get(Run.class), getContext().get(TaskListener.class)).read(path, engineVersion).getData().get(key);
                 getContext().onSuccess(value);

--- a/src/main/java/io/jenkins/plugins/vault/VaultReadStep.java
+++ b/src/main/java/io/jenkins/plugins/vault/VaultReadStep.java
@@ -98,7 +98,7 @@ public class VaultReadStep extends Step {
         private int getEngineVersion(EnvVars environment) {
             if (step.engineVersion == null || step.engineVersion.isEmpty()) {
                 GlobalVaultConfiguration vaultConfig = GlobalConfiguration.all().get(GlobalVaultConfiguration.class);
-                return vaultConfig.getConfiguration().getEngineVersion();
+                return vaultConfig == null ? 2 : vaultConfig.getConfiguration().getEngineVersion();
             }
 
             return Integer.parseInt(Util.replaceMacro(step.engineVersion, environment));


### PR DESCRIPTION
This PR adds support for reading Vault Engine version from the global config file.

This make pipeline definitions cleaner