### PR TITLE
Updated to support other vault auth methods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.4</version>
+        <version>3.56</version>
         <relativePath />
     </parent>
     <groupId>io.jenkins.plugins</groupId>
@@ -13,7 +13,7 @@
     <packaging>hpi</packaging>
 
     <properties>
-        <jenkins.version>2.138.1</jenkins.version>
+        <jenkins.version>2.138.4</jenkins.version>
         <java.level>8</java.level>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
@@ -64,17 +64,22 @@
         <dependency>
             <groupId>com.datapipe.jenkins.plugins</groupId>
             <artifactId>hashicorp-vault-plugin</artifactId>
-            <version>2.4.0</version>
+            <version>3.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-api</artifactId>
-            <version>2.15</version>
+            <version>2.23.1</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.28</version>
+            <version>2.41</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-step-api</artifactId>
+            <version>2.18</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/io/jenkins/plugins/vault/VaultReadStep.java
+++ b/src/main/java/io/jenkins/plugins/vault/VaultReadStep.java
@@ -1,5 +1,6 @@
 package io.jenkins.plugins.vault;
 
+import com.bettercloud.vault.VaultConfig;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.datapipe.jenkins.vault.VaultAccessor;
 import com.datapipe.jenkins.vault.configuration.GlobalVaultConfiguration;
@@ -87,11 +88,16 @@ public class VaultReadStep extends Step {
 
             listener.getLogger().append(String.format("using vault credentials \"%s\" and url \"%s\"", credentialsId, vaultUrl));
 
-            VaultAccessor vaultAccessor = new VaultAccessor();
-
             VaultCredential credentials = CredentialsProvider.findCredentialById(credentialsId, VaultCredential.class, run);
 
-            vaultAccessor.init(vaultUrl, credentials);
+            VaultConfig config = null;
+            if (vaultConfig != null) config = vaultConfig.getConfiguration().getVaultConfig();
+            if (config == null) config = new VaultConfig();
+            config.address(vaultUrl);
+
+            VaultAccessor vaultAccessor = new VaultAccessor(config, credentials);
+
+            vaultAccessor.init();
             return vaultAccessor;
         }
 


### PR DESCRIPTION
This PR updates the plugin to support newer vault auth methods (vault credential kinds) already implemented in the hashicorp vault plugin