### PR TITLE
Fix compatibility with newest hashicorp-vault-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,8 +4,8 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.4</version>
-        <relativePath />
+        <version>4.40</version>
+        <relativePath/>
     </parent>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>hashicorp-vault-pipeline</artifactId>
@@ -13,17 +13,12 @@
     <packaging>hpi</packaging>
 
     <properties>
-        <jenkins.version>2.138.1</jenkins.version>
-        <java.level>8</java.level>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <junit.version>4.1</junit.version>
-        <jenkins-pipeline-unit.version>1.1</jenkins-pipeline-unit.version>
+        <jenkins.version>2.332.1</jenkins.version>
+        <spotbugs.effort>Max</spotbugs.effort>
+        <spotbugs.failOnError>true</spotbugs.failOnError>
     </properties>
 
-
     <name>Hashicorp Vault Pipeline Plugin</name>
-    <description>Enables pulling of vault values as a pipeline step</description>
     <url>https://github.com/jenkinsci/hashicorp-vault-pipeline-plugin/</url>
     <licenses>
         <license>
@@ -42,10 +37,9 @@
     <scm>
         <connection>scm:git:ssh://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/jenkinsci/${project.artifactId}-plugin.git</developerConnection>
-        <url>http://github.com/jenkinsci/${project.artifactId}-plugin</url>
-        <tag>hashicorp-vault-pipeline-1.1</tag>
+        <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
+        <tag>hashicorp-vault-pipeline-1.4</tag>
     </scm>
-
 
     <repositories>
         <repository>
@@ -60,21 +54,22 @@
         </pluginRepository>
     </pluginRepositories>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.332.x</artifactId>
+                <version>1195.v33041c1f1b_b_2</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>com.datapipe.jenkins.plugins</groupId>
             <artifactId>hashicorp-vault-plugin</artifactId>
-            <version>2.4.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-api</artifactId>
-            <version>2.15</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-cps</artifactId>
-            <version>2.28</version>
+            <version>336.v182c0fbaaeb7</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<div>
+    Enables pulling of vault values as a pipeline step.
+</div>


### PR DESCRIPTION
- Update parent version to 4.40
- Update base jenkins version to 2.332.1 (LTS)
- Replace <description> tag with index.jelly per build instructions
- Add Jenkins BOM to simplify dependency management
- Adapt fix from https://github.com/jenkinsci/hashicorp-vault-pipeline-plugin/pull/15
  to a newer codebase

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
